### PR TITLE
Edited titles to WN pages

### DIFF
--- a/src/pages/notes/bleak-house/index.mdx
+++ b/src/pages/notes/bleak-house/index.mdx
@@ -1,6 +1,6 @@
 ---
 layout: "../../../layouts/notes.astro"
-title: "The Working Notes for Bleak House"
+title: "Bleak House Working Notes"
 editor: "Adam Grener"
 publishDate: "2020-03-02 00:00:00"
 description: "Working Notes from Dickens's novel Bleak House"

--- a/src/pages/notes/david-copperfield/index.mdx
+++ b/src/pages/notes/david-copperfield/index.mdx
@@ -1,9 +1,9 @@
 ---
 layout: "../../../layouts/notes.astro"
-title: "David Copperfield"
+title: "David Copperfield Working Notes"
 editor: "Frankie Goodenough"
 publishDate: "2020-03-02 00:00:00"
-description: "Working Notes from Dicken's novel David Copperfield."
+description: "Working Notes for Charles Dickens's novel David Copperfield."
 manifest: "https://dickensnotes.github.io/dickens-annotations/img/derivatives/iiif/davidcopperfieldtranscription/manifest.json"
 ---
 


### PR DESCRIPTION
Edited the titles for the BH and DC Working Notes pages to shorten them. Edited description for DC to correct typo.