### PR TITLE
Stick footer to bottom on short pages

### DIFF
--- a/src/layouts/notes.astro
+++ b/src/layouts/notes.astro
@@ -11,7 +11,7 @@ const { content } = Astro.props;
     <MainHead title={content.title} description={content.description} />
   </head>
 
-  <body class="container mx-auto">
+  <body class="container mx-auto flex flex-col h-screen justify-between">
     <Header />
     <div
       class="prose px-4 sm:px-6 prose-a:underline prose-a:decoration-ddnpblue prose-a:underline-offset-4 mx-auto"

--- a/src/layouts/page.astro
+++ b/src/layouts/page.astro
@@ -11,7 +11,7 @@ const { content } = Astro.props;
     <MainHead title={content.title} description={content.description} />
   </head>
 
-  <body class="container mx-auto">
+  <body class="container mx-auto flex flex-col h-screen justify-between">
     <Header />
     <div
       class="prose px-4 sm:px-6 prose-a:underline prose-a:decoration-ddnpblue prose-a:underline-offset-4 mx-auto"


### PR DESCRIPTION
Fixes #85

Uses flexbox and justify-between to keep the footer at bottom 