### PR TITLE
Switch text alignment on popovers

### DIFF
--- a/src/components/NavPopover.jsx
+++ b/src/components/NavPopover.jsx
@@ -56,7 +56,7 @@ export default function NavPopover({ title, options }) {
                           className="align-middle"
                         />
                       </div>
-                      <div className="ml-4">
+                      <div className="ml-4 text-left">
                         <p className="text-base font-medium text-gray-900">
                           {item.name}
                         </p>


### PR DESCRIPTION
Fixes #101 

@grenerad and @annamgibson I've left aligned the popover items to fix this alignment bug. I think it looks fine across browser widths, so haven't scoped it to just mobile, but let me know if you disagree. 