### PR TITLE
Add hr to give space to contact on Team page

### DIFF
--- a/src/pages/about/team.mdx
+++ b/src/pages/about/team.mdx
@@ -63,6 +63,8 @@ import PersonCard from "../../components/PersonCard.astro";
 
 Please see our [Credits & Acknowledgments](/credits-and-acknowledgments/) page for more on the institutions and people who have helped support the work of the Project Team.
 
+<hr />
+
 **CONTACT**
 
 Have a question for our team? Get in touch with us at dickensnotes@gmail.com


### PR DESCRIPTION
Fixes #205 

@annamgibson I added a horizontal rule for the moment. It's a bit tricky since this is all markdown. If you don't particularly like this, then we can pull the contact chunk into it's own component where we can style it a bit more effectively. Not a big lift, so let me know what works for you. 